### PR TITLE
feat: Add PlayerController, PlayerStats, VirtualJoystick, CameraFollow

### DIFF
--- a/roguelike-survivor-game/Assets/Scripts/Camera/CameraFollow.cs
+++ b/roguelike-survivor-game/Assets/Scripts/Camera/CameraFollow.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace RoguelikeSurvivor
+{
+    public class CameraFollow : MonoBehaviour
+    {
+        [SerializeField] private Transform _target;
+        [SerializeField] private float _smoothSpeed = 5f;
+        [SerializeField] private float _orthographicSize = 5f;
+
+        private const float CameraZ = -10f;
+
+        private void Start()
+        {
+            if (Camera.main != null)
+            {
+                Camera.main.orthographicSize = _orthographicSize;
+            }
+
+            // Snap to target immediately on start (no initial lerp lag)
+            if (_target != null)
+            {
+                Vector3 targetPos = _target.position;
+                transform.position = new Vector3(targetPos.x, targetPos.y, CameraZ);
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (_target == null) return;
+
+            Vector3 targetPosition = new Vector3(_target.position.x, _target.position.y, CameraZ);
+            float alpha = Mathf.Clamp01(_smoothSpeed * Time.deltaTime);
+            transform.position = Vector3.Lerp(transform.position, targetPosition, alpha);
+        }
+    }
+}

--- a/roguelike-survivor-game/Assets/Scripts/Player/PlayerController.cs
+++ b/roguelike-survivor-game/Assets/Scripts/Player/PlayerController.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace RoguelikeSurvivor
+{
+    [RequireComponent(typeof(Rigidbody2D))]
+    public class PlayerController : MonoBehaviour
+    {
+        [SerializeField] private PlayerStats _stats;
+        [SerializeField] private VirtualJoystick _virtualJoystick;
+
+        private Rigidbody2D _rb;
+        private InputSystem_Actions _inputActions;
+        private Vector2 _moveInput;
+
+        private void Awake()
+        {
+            _rb = GetComponent<Rigidbody2D>();
+            _inputActions = new InputSystem_Actions();
+        }
+
+        private void OnEnable()
+        {
+            _inputActions.Enable();
+        }
+
+        private void OnDisable()
+        {
+            _inputActions.Disable();
+        }
+
+        private void Update()
+        {
+            // Read keyboard/gamepad input from InputSystem
+            Vector2 keyboardInput = _inputActions.Player.Move.ReadValue<Vector2>();
+
+            // Prefer virtual joystick on mobile; fall back to keyboard
+            if (_virtualJoystick != null && _virtualJoystick.Direction.sqrMagnitude > 0.01f)
+            {
+                _moveInput = _virtualJoystick.Direction;
+            }
+            else
+            {
+                _moveInput = keyboardInput;
+            }
+
+            // Normalize to prevent diagonal speed boost
+            if (_moveInput.sqrMagnitude > 1f)
+            {
+                _moveInput.Normalize();
+            }
+        }
+
+        private void FixedUpdate()
+        {
+            if (_stats == null) return;
+
+            Vector2 newPosition = _rb.position + _moveInput * (_stats.MoveSpeed * Time.fixedDeltaTime);
+            _rb.MovePosition(newPosition);
+        }
+    }
+}

--- a/roguelike-survivor-game/Assets/Scripts/Player/PlayerStats.cs
+++ b/roguelike-survivor-game/Assets/Scripts/Player/PlayerStats.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+
+namespace RoguelikeSurvivor
+{
+    public class PlayerStats : MonoBehaviour
+    {
+        [SerializeField] private float _maxHP = 100f;
+        [SerializeField] private float _moveSpeed = 3f;
+        [SerializeField] private float _attackPower = 10f;
+        [SerializeField] private float _attackSpeed = 1f;
+        [SerializeField] private float _invincibilityDuration = 0.5f;
+
+        public float MaxHP => _maxHP;
+        public float CurrentHP { get; private set; }
+        public float MoveSpeed => _moveSpeed;
+        public float AttackPower => _attackPower;
+        public float AttackSpeed => _attackSpeed;
+        public bool IsInvincible => _invincibilityTimer > 0f;
+
+        private float _invincibilityTimer;
+
+        private void Awake()
+        {
+            CurrentHP = _maxHP;
+        }
+
+        private void Update()
+        {
+            if (_invincibilityTimer > 0f)
+            {
+                _invincibilityTimer -= Time.deltaTime;
+            }
+        }
+
+        public void TakeDamage(float amount)
+        {
+            if (IsInvincible) return;
+
+            CurrentHP -= amount;
+            _invincibilityTimer = _invincibilityDuration;
+
+            if (CurrentHP <= 0f)
+            {
+                CurrentHP = 0f;
+                EventBus.RaisePlayerDeath();
+            }
+        }
+
+        public void Heal(float amount)
+        {
+            CurrentHP = Mathf.Min(CurrentHP + amount, _maxHP);
+        }
+    }
+}

--- a/roguelike-survivor-game/Assets/Scripts/Player/VirtualJoystick.cs
+++ b/roguelike-survivor-game/Assets/Scripts/Player/VirtualJoystick.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace RoguelikeSurvivor
+{
+    public class VirtualJoystick : MonoBehaviour, IPointerDownHandler, IDragHandler, IPointerUpHandler
+    {
+        [SerializeField] private RectTransform _background;
+        [SerializeField] private RectTransform _handle;
+        [SerializeField] private float _range = 75f;
+
+        public Vector2 Direction { get; private set; }
+
+        private Vector2 _startPosition;
+        private Canvas _canvas;
+
+        private void Awake()
+        {
+            _canvas = GetComponentInParent<Canvas>();
+            _startPosition = _background.anchoredPosition;
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            if (RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                _background.parent as RectTransform,
+                eventData.position,
+                eventData.pressEventCamera,
+                out Vector2 localPoint))
+            {
+                _background.anchoredPosition = localPoint;
+            }
+            OnDrag(eventData);
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            if (!RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                _background,
+                eventData.position,
+                eventData.pressEventCamera,
+                out Vector2 localPoint)) return;
+
+            Vector2 offset = localPoint;
+            float magnitude = offset.magnitude;
+
+            if (magnitude > _range)
+            {
+                offset = offset.normalized * _range;
+            }
+
+            _handle.anchoredPosition = offset;
+            Direction = offset / _range;
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            Direction = Vector2.zero;
+            _handle.anchoredPosition = Vector2.zero;
+            _background.anchoredPosition = _startPosition;
+        }
+    }
+}


### PR DESCRIPTION
## Phase 1 — Player Movement + Camera Follow

### Changes
- `PlayerStats.cs`: HP stats, TakeDamage with 0.5s invincibility, EventBus.RaisePlayerDeath() on death
- `PlayerController.cs`: Rigidbody2D.MovePosition() in FixedUpdate, New InputSystem + VirtualJoystick hybrid, normalizes diagonal input
- `VirtualJoystick.cs`: Touch handlers, clamps handle within range, outputs normalized Direction
- `CameraFollow.cs`: LateUpdate Lerp follow, portrait mode, snaps on Start

### Acceptance Criteria
- [x] Rigidbody2D.MovePosition() in FixedUpdate
- [x] New InputSystem Move action used
- [x] VirtualJoystick for mobile
- [x] Camera smoothly follows player (Vector3.Lerp)
- [x] Portrait mode orthographic size
- [x] Compiles with zero errors