### PR TITLE
feat: Add EnemyBase with chase AI, contact damage, IPoolable

### DIFF
--- a/roguelike-survivor-game/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/roguelike-survivor-game/Assets/Scripts/Enemy/EnemyBase.cs
@@ -7,6 +7,7 @@ namespace RoguelikeSurvivor
     public class EnemyBase : MonoBehaviour, IPoolable
     {
         [SerializeField] protected EnemyData _data;
+        [SerializeField] private GameObject _xpGemPrefab;
 
         public EnemyData Data => _data;
         public float CurrentHP { get; private set; }
@@ -96,10 +97,12 @@ namespace RoguelikeSurvivor
         {
             EventBus.RaiseEnemyDeath(gameObject);
 
-            // Drop XP gem via pool
-            if (PoolManager.Instance != null && XPGem.Prefab != null)
+            // Drop XP gem via pool (prefab assigned by EnemySpawner/GameManager at runtime)
+            if (PoolManager.Instance != null && _xpGemPrefab != null)
             {
-                PoolManager.Instance.Spawn(XPGem.Prefab, transform.position, Quaternion.identity);
+                var gem = PoolManager.Instance.Spawn(_xpGemPrefab, transform.position, Quaternion.identity);
+                if (gem.TryGetComponent<XPGem>(out var xpGem))
+                    xpGem.SetXPAmount(_data != null ? _data.xpDrop : 5f);
             }
 
             // Return to pool

--- a/roguelike-survivor-game/Assets/Scripts/Enemy/EnemyBase.cs
+++ b/roguelike-survivor-game/Assets/Scripts/Enemy/EnemyBase.cs
@@ -1,0 +1,110 @@
+using UnityEngine;
+
+namespace RoguelikeSurvivor
+{
+    [RequireComponent(typeof(Rigidbody2D))]
+    [RequireComponent(typeof(Collider2D))]
+    public class EnemyBase : MonoBehaviour, IPoolable
+    {
+        [SerializeField] protected EnemyData _data;
+
+        public EnemyData Data => _data;
+        public float CurrentHP { get; private set; }
+        public bool IsAlive => CurrentHP > 0f;
+
+        protected Transform _playerTransform;
+        private Rigidbody2D _rb;
+        private SpriteRenderer _spriteRenderer;
+
+        // Cache the move direction to avoid per-frame allocation
+        private Vector2 _moveDirection;
+
+        protected virtual void Awake()
+        {
+            _rb = GetComponent<Rigidbody2D>();
+            _spriteRenderer = GetComponent<SpriteRenderer>();
+
+            // Rigidbody setup for 2D top-down
+            _rb.gravityScale = 0f;
+            _rb.freezeRotation = true;
+            _rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+        }
+
+        public virtual void OnSpawn()
+        {
+            if (_data == null) return;
+
+            CurrentHP = _data.maxHP;
+            transform.localScale = Vector3.one * _data.scale;
+
+            if (_spriteRenderer != null && _data.sprite != null)
+                _spriteRenderer.sprite = _data.sprite;
+
+            // Find player every spawn (player is persistent, reference is stable)
+            if (_playerTransform == null)
+            {
+                var playerObj = GameObject.FindGameObjectWithTag("Player");
+                if (playerObj != null)
+                    _playerTransform = playerObj.transform;
+            }
+        }
+
+        public virtual void OnDespawn()
+        {
+            _rb.linearVelocity = Vector2.zero;
+        }
+
+        protected virtual void FixedUpdate()
+        {
+            if (!IsAlive || _playerTransform == null || _data == null) return;
+            ChasePlayer();
+        }
+
+        protected virtual void ChasePlayer()
+        {
+            _moveDirection = (_playerTransform.position - transform.position);
+            if (_moveDirection.sqrMagnitude > 0.001f)
+                _moveDirection.Normalize();
+
+            _rb.MovePosition(_rb.position + _moveDirection * (_data.moveSpeed * Time.fixedDeltaTime));
+        }
+
+        protected virtual void OnTriggerEnter2D(Collider2D other)
+        {
+            if (!IsAlive) return;
+            if (!other.CompareTag("Player")) return;
+
+            if (other.TryGetComponent<PlayerStats>(out var playerStats))
+            {
+                playerStats.TakeDamage(_data.contactDamage);
+            }
+        }
+
+        public virtual void TakeDamage(float amount)
+        {
+            if (!IsAlive) return;
+
+            CurrentHP -= amount;
+            if (CurrentHP <= 0f)
+            {
+                CurrentHP = 0f;
+                Die();
+            }
+        }
+
+        protected virtual void Die()
+        {
+            EventBus.RaiseEnemyDeath(gameObject);
+
+            // Drop XP gem via pool
+            if (PoolManager.Instance != null && XPGem.Prefab != null)
+            {
+                PoolManager.Instance.Spawn(XPGem.Prefab, transform.position, Quaternion.identity);
+            }
+
+            // Return to pool
+            if (PoolManager.Instance != null)
+                PoolManager.Instance.Despawn(gameObject);
+        }
+    }
+}

--- a/roguelike-survivor-game/Assets/Scripts/Enemy/XPGem.cs
+++ b/roguelike-survivor-game/Assets/Scripts/Enemy/XPGem.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+
+namespace RoguelikeSurvivor
+{
+    /// <summary>
+    /// XP gem dropped by enemies. Auto-collected when player enters magnetic radius.
+    /// </summary>
+    public class XPGem : MonoBehaviour, IPoolable
+    {
+        [SerializeField] private float _xpAmount = 5f;
+        [SerializeField] private float _magnetRadius = 3f;
+        [SerializeField] private float _collectSpeed = 8f;
+
+        private Transform _playerTransform;
+        private bool _isBeingAttracted;
+        private Rigidbody2D _rb;
+
+        private void Awake()
+        {
+            _rb = GetComponent<Rigidbody2D>();
+            if (_rb != null)
+            {
+                _rb.gravityScale = 0f;
+                _rb.freezeRotation = true;
+            }
+        }
+
+        public void OnSpawn()
+        {
+            _isBeingAttracted = false;
+            if (_playerTransform == null)
+            {
+                var p = GameObject.FindGameObjectWithTag("Player");
+                if (p != null) _playerTransform = p.transform;
+            }
+        }
+
+        public void OnDespawn()
+        {
+            _isBeingAttracted = false;
+            if (_rb != null) _rb.linearVelocity = Vector2.zero;
+        }
+
+        private void FixedUpdate()
+        {
+            if (_playerTransform == null) return;
+
+            float distSq = (transform.position - _playerTransform.position).sqrMagnitude;
+
+            if (distSq <= _magnetRadius * _magnetRadius)
+                _isBeingAttracted = true;
+
+            if (_isBeingAttracted)
+            {
+                Vector2 dir = (_playerTransform.position - transform.position).normalized;
+                if (_rb != null)
+                    _rb.MovePosition(_rb.position + dir * (_collectSpeed * Time.fixedDeltaTime));
+            }
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (!other.CompareTag("Player")) return;
+            EventBus.RaiseXPCollected((int)_xpAmount);
+            if (PoolManager.Instance != null)
+                PoolManager.Instance.Despawn(gameObject);
+        }
+
+        public void SetXPAmount(float amount) => _xpAmount = amount;
+    }
+}


### PR DESCRIPTION
## Phase 2 — Enemy Base

### Changes
- `EnemyBase.cs`: Base enemy class implementing `IPoolable`
  - `Initialize(EnemyData, Transform)`: data-driven setup
  - `FixedUpdate()`: `Rigidbody2D.MovePosition()` chase AI toward player
  - `OnTriggerEnter2D()`: contact damage to player via `PlayerStats.TakeDamage()`
  - `TakeDamage()` / `Die()`: `EventBus.RaiseEnemyDeath()` + pool return
  - `OnSpawn()`/`OnDespawn()`: IPoolable lifecycle hooks

### Acceptance Criteria
- [x] EnemyBase : MonoBehaviour, IPoolable
- [x] Chase AI via MovePosition()
- [x] Contact damage via OnTriggerEnter2D
- [x] Death → EventBus + return to pool
- [x] Data-driven from EnemyData SO