### PR TITLE
fix: AudioManager event sub pattern, ResultScreen uses LevelUpSystem

### DIFF
--- a/roguelike-survivor-game/Assets/Scripts/Audio/AudioManager.cs
+++ b/roguelike-survivor-game/Assets/Scripts/Audio/AudioManager.cs
@@ -10,7 +10,7 @@ namespace RoguelikeSurvivor
         public static AudioManager Instance { get; private set; }
 
         [SerializeField] private AudioSource _bgmSource;
-        [SerializeField] private AudioSource[] _sePool;  // 6 SE sources
+        [SerializeField] private AudioSource[] _sePool;  // 6 SE sources recommended
 
         [Header("BGM")]
         [SerializeField] private AudioClip _bgmClip;
@@ -32,21 +32,28 @@ namespace RoguelikeSurvivor
             DontDestroyOnLoad(gameObject);
         }
 
+        private void OnEnable()
+        {
+            EventBus.OnEnemyDeath += HandleEnemyDeath;
+            EventBus.OnLevelUp += HandleLevelUp;
+            EventBus.OnPlayerDeath += HandlePlayerDeath;
+        }
+
+        private void OnDisable()
+        {
+            EventBus.OnEnemyDeath -= HandleEnemyDeath;
+            EventBus.OnLevelUp -= HandleLevelUp;
+            EventBus.OnPlayerDeath -= HandlePlayerDeath;
+        }
+
         private void Start()
         {
             PlayBGM();
-
-            EventBus.OnEnemyDeath += _ => PlaySE(_seEnemyDie);
-            EventBus.OnLevelUp += _ => PlaySE(_seLevelUp);
-            EventBus.OnPlayerDeath += () => StopBGM();
         }
 
-        private void OnDestroy()
-        {
-            EventBus.OnEnemyDeath -= _ => PlaySE(_seEnemyDie);
-            EventBus.OnLevelUp -= _ => PlaySE(_seLevelUp);
-            EventBus.OnPlayerDeath -= () => StopBGM();
-        }
+        private void HandleEnemyDeath(GameObject _) => PlaySE(_seEnemyDie);
+        private void HandleLevelUp(int _) => PlaySE(_seLevelUp);
+        private void HandlePlayerDeath() => StopBGM();
 
         public void PlayBGM()
         {
@@ -65,14 +72,12 @@ namespace RoguelikeSurvivor
         public void PlaySE(AudioClip clip)
         {
             if (clip == null || _sePool == null || _sePool.Length == 0) return;
-
-            // Round-robin pool to prevent cut-off on rapid hits
             var source = _sePool[_seIndex % _sePool.Length];
             _seIndex++;
             source.PlayOneShot(clip);
         }
 
-        // Convenience wrappers for easy call from code
+        // Convenience wrappers
         public void PlayAttackFire() => PlaySE(_seAttackFire);
         public void PlayEnemyHit() => PlaySE(_seEnemyHit);
         public void PlayEnemyDie() => PlaySE(_seEnemyDie);

--- a/roguelike-survivor-game/Assets/Scripts/UI/ResultScreen.cs
+++ b/roguelike-survivor-game/Assets/Scripts/UI/ResultScreen.cs
@@ -13,41 +13,30 @@ namespace RoguelikeSurvivor
         [SerializeField] private TMP_Text _levelReachedText;
         [SerializeField] private Button _retryButton;
 
-        private int _enemyKillCount;
         private float _survivalTime;
 
         private void Start()
         {
             _panelRoot.SetActive(false);
-
-            EventBus.OnGameOver += OnGameOver;
-            EventBus.OnPlayerDeath += OnGameOver;
-            EventBus.OnEnemyDeath += OnEnemyDeath;
-
             _retryButton?.onClick.AddListener(OnRetry);
         }
 
-        private void OnDestroy()
+        private void OnEnable()
         {
-            EventBus.OnGameOver -= OnGameOver;
-            EventBus.OnPlayerDeath -= OnGameOver;
-            EventBus.OnEnemyDeath -= OnEnemyDeath;
+            EventBus.OnGameOver += ShowResult;
+            EventBus.OnPlayerDeath += ShowResult;
+        }
+
+        private void OnDisable()
+        {
+            EventBus.OnGameOver -= ShowResult;
+            EventBus.OnPlayerDeath -= ShowResult;
         }
 
         private void Update()
         {
             if (GameManager.Instance != null && GameManager.Instance.CurrentState == GameState.Playing)
                 _survivalTime = GameManager.Instance.ElapsedTime;
-        }
-
-        private void OnEnemyDeath(GameObject _)
-        {
-            _enemyKillCount++;
-        }
-
-        private void OnGameOver()
-        {
-            ShowResult();
         }
 
         private void ShowResult()
@@ -59,13 +48,13 @@ namespace RoguelikeSurvivor
             if (_survivalTimeText != null)
                 _survivalTimeText.text = $"Survived: {minutes:00}:{seconds:00}";
 
+            int kills = LevelUpSystem.Instance != null ? LevelUpSystem.Instance.GetEnemiesKilled() : 0;
             if (_enemiesKilledText != null)
-                _enemiesKilledText.text = $"Enemies: {_enemyKillCount}";
+                _enemiesKilledText.text = $"Enemies: {kills}";
 
-            // Get level from PlayerXP
-            var playerXP = FindFirstObjectByType<PlayerXP>();
+            int level = LevelUpSystem.Instance != null ? LevelUpSystem.Instance.Level : 1;
             if (_levelReachedText != null)
-                _levelReachedText.text = $"Level: {(playerXP != null ? playerXP.Level : 1)}";
+                _levelReachedText.text = $"Level: {level}";
         }
 
         private void OnRetry()


### PR DESCRIPTION
- Fix AudioManager lambda subscriptions (replaced with named handlers in OnEnable/OnDisable)
- ResultScreen now reads LevelUpSystem.Instance for kill count and level